### PR TITLE
Expiry must be configured in days but was used as seconds

### DIFF
--- a/src/main/java/com/farao_community/farao/minio_adapter/starter/MinioAdapter.java
+++ b/src/main/java/com/farao_community/farao/minio_adapter/starter/MinioAdapter.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -150,7 +151,7 @@ public class MinioAdapter {
                     GetPresignedObjectUrlArgs.builder()
                             .bucket(defaultBucket)
                             .object(pathDestination)
-                            .expiry(expiryInDays)
+                            .expiry(expiryInDays, TimeUnit.DAYS)
                             .method(Method.GET)
                             .build()
             );


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Presigned URL expiry was said to be expressed in days, but the one sent to MinIO is in seconds.


**What is the new behavior (if this is a feature change)?**
Presigned URL expiry in days is correctly converted for MinIO client


**Does this PR introduce a breaking change?** *(What changes might users need to make in their application due to this PR?)*



**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
